### PR TITLE
Dev

### DIFF
--- a/includes/class-view.php
+++ b/includes/class-view.php
@@ -386,12 +386,19 @@ final class VAA_View_Admin_As_View extends VAA_View_Admin_As_Class_Base
 		 * @since  1.7.2
 		 * @see    WP_User::has_cap()
 		 */
+		$new_user = new WP_User() ;
+		// add the selected user's roles to the user we just created...
+		// this is necessary to allow other plugins that have hooked into user_has_cap
+		// with a function that acts based on a user's role.
+		foreach ( $this->store->get_selectedUser()->roles as $role ) {
+			$new_user->add_role( $role ) ;
+		}
 		$filter_caps = apply_filters( 'user_has_cap',
 			$filter_caps,
 			$caps,
 			// Replicate arguments for `user_has_cap`.
 			array_merge( array( $cap, 0 ), (array) $args ),
-			new WP_User()
+			$new_user
 		);
 
 		foreach ( (array) $caps as $actual_cap ) {

--- a/includes/class-view.php
+++ b/includes/class-view.php
@@ -378,6 +378,11 @@ final class VAA_View_Admin_As_View extends VAA_View_Admin_As_Class_Base
 
 		/**
 		 * Apply user_has_cap filters to make sure we are compatible with modifications from other plugins.
+		 *
+		 * Do not supply the current user with this filter to prevent plugins from overwriting our functionality.
+		 * Issues found:
+		 * - Restrict User Access
+		 *
 		 * @since  1.7.2
 		 * @see    WP_User::has_cap()
 		 */
@@ -385,8 +390,8 @@ final class VAA_View_Admin_As_View extends VAA_View_Admin_As_Class_Base
 			$filter_caps,
 			$caps,
 			// Replicate arguments for `user_has_cap`.
-			array_merge( array( $cap, $user_id ), (array) $args ),
-			$this->store->get_selectedUser()
+			array_merge( array( $cap, 0 ), (array) $args ),
+			new WP_User()
 		);
 
 		foreach ( (array) $caps as $actual_cap ) {

--- a/includes/class-view.php
+++ b/includes/class-view.php
@@ -396,8 +396,6 @@ final class VAA_View_Admin_As_View extends VAA_View_Admin_As_Class_Base
 
 		foreach ( (array) $caps as $actual_cap ) {
 			if ( ! $this->current_view_can( $actual_cap, $filter_caps ) ) {
-				// Regular users.
-				$caps[ $cap ] = 0;
 				// Network admins.
 				$caps['do_not_allow'] = 'do_not_allow';
 			}


### PR DESCRIPTION
The change you made did not fix the problem because the new WP_User you pass when applying `user_has_cap` had no roles...hence, the function I hook into `user_has_cap` didn't do the right thing since it has a `if (in_array ('some_role', $user->roles))` check.

This change fixes that by adding roles from the "selectedUser" to the user created via new WP_User.  Since you know your code much better than I do you might have a better way of doing that.

I've tested this fix with both the stripped down "test" plugin I sent you and the full private plugin I wrote that originally uncovered the issue.

**Note**: I'm new to this "pull request" thing.  I'm not sure why, but this request includes the last 2 commits you made.  I expected it to include only the commit I made in my fork.  I'm sure you can reconcile that.