### PR TITLE
URE Integration: Fix the level at which the View Admin As group appears in the URE Custom Capabilities UI

### DIFF
--- a/includes/class-compat.php
+++ b/includes/class-compat.php
@@ -468,7 +468,7 @@ final class VAA_View_Admin_As_Compat extends VAA_View_Admin_As_Base
 		$groups['view_admin_as'] = array(
 			'caption' => esc_html__( 'View Admin As', VIEW_ADMIN_AS_DOMAIN ),
 			'parent'  => 'custom',
-			'level'   => 3,
+			'level'   => 2,
 		);
 		return $groups;
 	}


### PR DESCRIPTION
Fixes #134

## Proposed Changes

  - change the level at which the VAA group is added from 3 to 2.

Screenshot w/ PR applied

![vaa-ure-custom-caps-after-pr](https://github.com/user-attachments/assets/06d7234d-cd83-4150-8be6-989a6e5f488a)

Compare the above screenshot with the one in #134 